### PR TITLE
A11y workshop contrib clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Example with the [JupyterLab Miami Nights Theme](https://github.com/timkpaine/ju
 
 ### File Editor 🖊️
 
-![image A RetroLab editor of a Python file with a function and a statement in it](https://user-images.githubusercontent.com/591645/101953590-e2ed5700-3bfa-11eb-9fee-0b6d964f0949.png)
+![A RetroLab editor of a Python file with a function and a statement in it](https://user-images.githubusercontent.com/591645/101953590-e2ed5700-3bfa-11eb-9fee-0b6d964f0949.png)
 
 ### Compact View on Mobile Devices 📱
 

--- a/README.md
+++ b/README.md
@@ -89,25 +89,25 @@ To access the main RetroLab tree (file browser):
 
 ### Files 📂 and Running Sessions 🏃‍♀️
 
-![tree](https://user-images.githubusercontent.com/591645/101952684-54c4a100-3bf9-11eb-8031-6900f6d3a445.gif)
+![tree ...](https://user-images.githubusercontent.com/591645/101952684-54c4a100-3bf9-11eb-8031-6900f6d3a445.gif)
 
 ### Notebook 📒
 
-![notebook](https://user-images.githubusercontent.com/591645/101953039-efbd7b00-3bf9-11eb-9d34-3cb663a5ac43.gif)
+![notebook ...](https://user-images.githubusercontent.com/591645/101953039-efbd7b00-3bf9-11eb-9d34-3cb663a5ac43.gif)
 
 ### Open in a new Browser Tab by default
 
-![new-browser-tab](https://user-images.githubusercontent.com/591645/118811914-d9ed6980-b8ad-11eb-8362-f38627199f71.gif)
+![new-browser-tab ...](https://user-images.githubusercontent.com/591645/118811914-d9ed6980-b8ad-11eb-8362-f38627199f71.gif)
 
 ### Command Palette 🎨
 
-![command-palette](https://user-images.githubusercontent.com/591645/101953322-72ded100-3bfa-11eb-9b13-3a912e4f6844.gif)
+![command-palette ...](https://user-images.githubusercontent.com/591645/101953322-72ded100-3bfa-11eb-9b13-3a912e4f6844.gif)
 
 ### Themes 🌈
 
 Support for existing JupyterLab themes!
 
-![themes](https://user-images.githubusercontent.com/591645/101953333-75d9c180-3bfa-11eb-868f-af54d1ea7091.gif)
+![themes ...](https://user-images.githubusercontent.com/591645/101953333-75d9c180-3bfa-11eb-868f-af54d1ea7091.gif)
 
 For an even more retro look, you might want to start `retrolab` with the `--retro-logo` CLI flag:
 
@@ -120,33 +120,33 @@ jupyter retro --retro-logo
 
 Example with the [JupyterLab Miami Nights Theme](https://github.com/timkpaine/jupyterlab_miami_nights) installed as a prebuilt extension:
 
-![image](https://user-images.githubusercontent.com/591645/119634905-77e3b580-be13-11eb-9c4c-d187ebea9df8.png)
+![image ...](https://user-images.githubusercontent.com/591645/119634905-77e3b580-be13-11eb-9c4c-d187ebea9df8.png)
 
 ### Zen Mode 😌
 
-![compact-zen-mode](https://user-images.githubusercontent.com/591645/101923740-149cf880-3bd0-11eb-9617-e3349a76d034.gif)
+![compact-zen-mode ...](https://user-images.githubusercontent.com/591645/101923740-149cf880-3bd0-11eb-9617-e3349a76d034.gif)
 
 ### Terminals 🖥️
 
-![terminals](https://user-images.githubusercontent.com/591645/118793525-fc28bc80-b898-11eb-9e02-d5a80ad8ddb8.gif)
+![terminals ...](https://user-images.githubusercontent.com/591645/118793525-fc28bc80-b898-11eb-9e02-d5a80ad8ddb8.gif)
 
 ### File Editor 🖊️
 
-![image](https://user-images.githubusercontent.com/591645/101953590-e2ed5700-3bfa-11eb-9fee-0b6d964f0949.png)
+![image ...](https://user-images.githubusercontent.com/591645/101953590-e2ed5700-3bfa-11eb-9fee-0b6d964f0949.png)
 
 ### Compact View on Mobile Devices 📱
 
-![mobile](https://user-images.githubusercontent.com/591645/101995448-2793f380-3cca-11eb-8971-067dd068ccbe.gif)
+![mobile ...](https://user-images.githubusercontent.com/591645/101995448-2793f380-3cca-11eb-8971-067dd068ccbe.gif)
 
 ### Support for prebuilt extensions 🧩
 
 Install new extensions easily!
 
-![federated-extensions](https://user-images.githubusercontent.com/591645/118813222-38671780-b8af-11eb-835b-f2865bab5c62.gif)
+![federated-extensions ...](https://user-images.githubusercontent.com/591645/118813222-38671780-b8af-11eb-835b-f2865bab5c62.gif)
 
 ### Switch between JupyterLab and RetroLab easily ↔️
 
-![jupyterlab-switch](https://user-images.githubusercontent.com/591645/118816963-05bf1e00-b8b3-11eb-92a2-899288471011.gif)
+![jupyterlab-switch ...](https://user-images.githubusercontent.com/591645/118816963-05bf1e00-b8b3-11eb-92a2-899288471011.gif)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Example with the [JupyterLab Miami Nights Theme](https://github.com/timkpaine/ju
 
 ### Terminals 🖥️
 
-![terminals An animation of a user launching a terminal in a new browser tab and executing a command in it](https://user-images.githubusercontent.com/591645/118793525-fc28bc80-b898-11eb-9e02-d5a80ad8ddb8.gif)
+![An animation of a user launching a terminal in a new browser tab and executing a command in it](https://user-images.githubusercontent.com/591645/118793525-fc28bc80-b898-11eb-9e02-d5a80ad8ddb8.gif)
 
 ### File Editor 🖊️
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ To access the main RetroLab tree (file browser):
 
 Support for existing JupyterLab themes!
 
-![themes An animation of a user changing the Jupyter interface to use the dark theme.](https://user-images.githubusercontent.com/591645/101953333-75d9c180-3bfa-11eb-868f-af54d1ea7091.gif)
+![An animation of a user changing the Jupyter interface to use the dark theme.](https://user-images.githubusercontent.com/591645/101953333-75d9c180-3bfa-11eb-868f-af54d1ea7091.gif)
 
 For an even more retro look, you might want to start `retrolab` with the `--retro-logo` CLI flag:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Classic_) is a [JupyterLab](https://github.com/jupyterlab/jupyterlab)
 distribution with a retro look and feel, more similar to the classic
 [Jupyter notebook](https://github.com/jupyter/notebook).
 
-![retrolab](https://user-images.githubusercontent.com/591645/138552467-ed2d96ff-1ea3-496c-bc7b-660d009c1459.png)
+![A notebook in RetroLab.](https://user-images.githubusercontent.com/591645/138552467-ed2d96ff-1ea3-496c-bc7b-660d009c1459.png)
 
 ## Try it online in your browser
 
@@ -89,25 +89,25 @@ To access the main RetroLab tree (file browser):
 
 ### Files 📂 and Running Sessions 🏃‍♀️
 
-![An animation showing the abilities of RetroLab. It shows the ability to make folders, move files, and create new ones.](https://user-images.githubusercontent.com/591645/101952684-54c4a100-3bf9-11eb-8031-6900f6d3a445.gif)
+![An animation of how to make folders, move files, create files, and display running notebooks and terminals in RetroLab's filebrowser.](https://user-images.githubusercontent.com/591645/101952684-54c4a100-3bf9-11eb-8031-6900f6d3a445.gif)
 
 ### Notebook 📒
 
-![notebook An animation showing a user viewing a notebook, renaming a file, running cells, interacting with cell output, and modifying the Jupyter interface using the menu](https://user-images.githubusercontent.com/591645/101953039-efbd7b00-3bf9-11eb-9d34-3cb663a5ac43.gif)
+![An animation of viewing a notebook, renaming a file, running cells, interacting with cell output, and modifying the Jupyter interface using the menu.](https://user-images.githubusercontent.com/591645/101953039-efbd7b00-3bf9-11eb-9d34-3cb663a5ac43.gif)
 
 ### Open in a new Browser Tab by default
 
-![An example of creating a new notebook that opens a new tab and prompts to select a kernel. It shows executing a cell that shows and output then saves the result. It returns back to the file browser to show the notebooking in the running panel.](https://user-images.githubusercontent.com/591645/118811914-d9ed6980-b8ad-11eb-8362-f38627199f71.gif)
+![An example of creating a notebook as a new browser tab and running a cell in it.It returns back to the file browser to show the notebooking in the running panel.](https://user-images.githubusercontent.com/591645/118811914-d9ed6980-b8ad-11eb-8362-f38627199f71.gif)
 
 ### Command Palette 🎨
 
-![command-palette An animation of a user opening the command palette and selecting the "Restart Kernel and Clear All Outputs …" option](https://user-images.githubusercontent.com/591645/101953322-72ded100-3bfa-11eb-9b13-3a912e4f6844.gif)
+![An animation of opening the command palette and selecting the "Restart Kernel and Clear All Outputs" option.](https://user-images.githubusercontent.com/591645/101953322-72ded100-3bfa-11eb-9b13-3a912e4f6844.gif)
 
 ### Themes 🌈
 
 Support for existing JupyterLab themes!
 
-![themes An animation of a user changing the Jupyter interface to use the dark theme.](https://user-images.githubusercontent.com/591645/101953333-75d9c180-3bfa-11eb-868f-af54d1ea7091.gif)
+![An animation of a changing the RetroLab interface to dark theme from the Settingsm menu.](https://user-images.githubusercontent.com/591645/101953333-75d9c180-3bfa-11eb-868f-af54d1ea7091.gif)
 
 For an even more retro look, you might want to start `retrolab` with the `--retro-logo` CLI flag:
 
@@ -120,29 +120,29 @@ jupyter retro --retro-logo
 
 Example with the [JupyterLab Miami Nights Theme](https://github.com/timkpaine/jupyterlab_miami_nights) installed as a prebuilt extension:
 
-![image The Jupyter interface using the Miami Nights theme](https://user-images.githubusercontent.com/591645/119634905-77e3b580-be13-11eb-9c4c-d187ebea9df8.png)
+![RetroLab using the Miami Nights theme.](https://user-images.githubusercontent.com/591645/119634905-77e3b580-be13-11eb-9c4c-d187ebea9df8.png)
 
 ### Zen Mode 😌
 
-![compact-zen-mode An animation of a user using the command palette to enable Zen Mode in JupyterLab](https://user-images.githubusercontent.com/591645/101923740-149cf880-3bd0-11eb-9617-e3349a76d034.gif)
+![An animation of using the command palette to enable Zen Mode, showing only notebook controls, in RetroLab.](https://user-images.githubusercontent.com/591645/101923740-149cf880-3bd0-11eb-9617-e3349a76d034.gif)
 
 ### Terminals 🖥️
 
-![terminals An animation of a user launching a terminal in a new browser tab and executing a command in it](https://user-images.githubusercontent.com/591645/118793525-fc28bc80-b898-11eb-9e02-d5a80ad8ddb8.gif)
+![An animation of launching a terminal in a new browser tab and executing a command in it.](https://user-images.githubusercontent.com/591645/118793525-fc28bc80-b898-11eb-9e02-d5a80ad8ddb8.gif)
 
 ### File Editor 🖊️
 
-![image A RetroLab editor of a Python file with a function and a statement in it](https://user-images.githubusercontent.com/591645/101953590-e2ed5700-3bfa-11eb-9fee-0b6d964f0949.png)
+![A RetroLab editor of a Python file with a function and a statement in it.](https://user-images.githubusercontent.com/591645/101953590-e2ed5700-3bfa-11eb-9fee-0b6d964f0949.png)
 
 ### Compact View on Mobile Devices 📱
 
-![mobile Animation of a user on a mobile phone-sized screen using a compact touch interface in JupyterLab](https://user-images.githubusercontent.com/591645/101995448-2793f380-3cca-11eb-8971-067dd068ccbe.gif)
+![Animation of RetroLab on a mobile device using a compact touch interface.](https://user-images.githubusercontent.com/591645/101995448-2793f380-3cca-11eb-8971-067dd068ccbe.gif)
 
 ### Support for prebuilt extensions 🧩
 
 Install new extensions easily!
 
-![An animation of installing an extension directly in a RetroLab by running commands in a notebook cell.](https://user-images.githubusercontent.com/591645/118813222-38671780-b8af-11eb-835b-f2865bab5c62.gif)
+![An animation of installing an extension directly in a RetroLab by running `pip install` in a notebook cell.](https://user-images.githubusercontent.com/591645/118813222-38671780-b8af-11eb-835b-f2865bab5c62.gif)
 
 ### Switch between JupyterLab and RetroLab easily ↔️
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To access the main RetroLab tree (file browser):
 
 ### Notebook 📒
 
-![notebook An animation showing a user viewing a notebook, renaming a file, running cells, interacting with cell output, and modifying the Jupyter interface using the menu](https://user-images.githubusercontent.com/591645/101953039-efbd7b00-3bf9-11eb-9d34-3cb663a5ac43.gif)
+![An animation showing a user viewing a notebook, renaming a file, running cells, interacting with cell output, and modifying the Jupyter interface using the menu](https://user-images.githubusercontent.com/591645/101953039-efbd7b00-3bf9-11eb-9d34-3cb663a5ac43.gif)
 
 ### Open in a new Browser Tab by default
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To access the main RetroLab tree (file browser):
 
 ### Command Palette 🎨
 
-![command-palette An animation of a user opening the command palette and selecting the "Restart Kernel and Clear All Outputs …" option](https://user-images.githubusercontent.com/591645/101953322-72ded100-3bfa-11eb-9b13-3a912e4f6844.gif)
+![An animation of a user opening the command palette and selecting the "Restart Kernel and Clear All Outputs …" option](https://user-images.githubusercontent.com/591645/101953322-72ded100-3bfa-11eb-9b13-3a912e4f6844.gif)
 
 ### Themes 🌈
 

--- a/README.md
+++ b/README.md
@@ -89,25 +89,25 @@ To access the main RetroLab tree (file browser):
 
 ### Files 📂 and Running Sessions 🏃‍♀️
 
-![tree ...](https://user-images.githubusercontent.com/591645/101952684-54c4a100-3bf9-11eb-8031-6900f6d3a445.gif)
+![An animation showing the abilities of RetroLab. It shows the ability to make folders, move files, and create new ones.](https://user-images.githubusercontent.com/591645/101952684-54c4a100-3bf9-11eb-8031-6900f6d3a445.gif)
 
 ### Notebook 📒
 
-![notebook ...](https://user-images.githubusercontent.com/591645/101953039-efbd7b00-3bf9-11eb-9d34-3cb663a5ac43.gif)
+![notebook An animation showing a user viewing a notebook, renaming a file, running cells, interacting with cell output, and modifying the Jupyter interface using the menu](https://user-images.githubusercontent.com/591645/101953039-efbd7b00-3bf9-11eb-9d34-3cb663a5ac43.gif)
 
 ### Open in a new Browser Tab by default
 
-![new-browser-tab ...](https://user-images.githubusercontent.com/591645/118811914-d9ed6980-b8ad-11eb-8362-f38627199f71.gif)
+![An example of creating a new notebook that opens a new tab and prompts to select a kernel. It shows executing a cell that shows and output then saves the result. It returns back to the file browser to show the notebooking in the running panel.](https://user-images.githubusercontent.com/591645/118811914-d9ed6980-b8ad-11eb-8362-f38627199f71.gif)
 
 ### Command Palette 🎨
 
-![command-palette ...](https://user-images.githubusercontent.com/591645/101953322-72ded100-3bfa-11eb-9b13-3a912e4f6844.gif)
+![command-palette An animation of a user opening the command palette and selecting the "Restart Kernel and Clear All Outputs …" option](https://user-images.githubusercontent.com/591645/101953322-72ded100-3bfa-11eb-9b13-3a912e4f6844.gif)
 
 ### Themes 🌈
 
 Support for existing JupyterLab themes!
 
-![themes ...](https://user-images.githubusercontent.com/591645/101953333-75d9c180-3bfa-11eb-868f-af54d1ea7091.gif)
+![themes An animation of a user changing the Jupyter interface to use the dark theme.](https://user-images.githubusercontent.com/591645/101953333-75d9c180-3bfa-11eb-868f-af54d1ea7091.gif)
 
 For an even more retro look, you might want to start `retrolab` with the `--retro-logo` CLI flag:
 
@@ -120,33 +120,33 @@ jupyter retro --retro-logo
 
 Example with the [JupyterLab Miami Nights Theme](https://github.com/timkpaine/jupyterlab_miami_nights) installed as a prebuilt extension:
 
-![image ...](https://user-images.githubusercontent.com/591645/119634905-77e3b580-be13-11eb-9c4c-d187ebea9df8.png)
+![image The Jupyter interface using the Miami Nights theme](https://user-images.githubusercontent.com/591645/119634905-77e3b580-be13-11eb-9c4c-d187ebea9df8.png)
 
 ### Zen Mode 😌
 
-![compact-zen-mode ...](https://user-images.githubusercontent.com/591645/101923740-149cf880-3bd0-11eb-9617-e3349a76d034.gif)
+![compact-zen-mode An animation of a user using the command palette to enable Zen Mode in JupyterLab](https://user-images.githubusercontent.com/591645/101923740-149cf880-3bd0-11eb-9617-e3349a76d034.gif)
 
 ### Terminals 🖥️
 
-![terminals ...](https://user-images.githubusercontent.com/591645/118793525-fc28bc80-b898-11eb-9e02-d5a80ad8ddb8.gif)
+![terminals An animation of a user launching a terminal in a new browser tab and executing a command in it](https://user-images.githubusercontent.com/591645/118793525-fc28bc80-b898-11eb-9e02-d5a80ad8ddb8.gif)
 
 ### File Editor 🖊️
 
-![image ...](https://user-images.githubusercontent.com/591645/101953590-e2ed5700-3bfa-11eb-9fee-0b6d964f0949.png)
+![image A RetroLab editor of a Python file with a function and a statement in it](https://user-images.githubusercontent.com/591645/101953590-e2ed5700-3bfa-11eb-9fee-0b6d964f0949.png)
 
 ### Compact View on Mobile Devices 📱
 
-![mobile ...](https://user-images.githubusercontent.com/591645/101995448-2793f380-3cca-11eb-8971-067dd068ccbe.gif)
+![mobile Animation of a user on a mobile phone-sized screen using a compact touch interface in JupyterLab](https://user-images.githubusercontent.com/591645/101995448-2793f380-3cca-11eb-8971-067dd068ccbe.gif)
 
 ### Support for prebuilt extensions 🧩
 
 Install new extensions easily!
 
-![federated-extensions ...](https://user-images.githubusercontent.com/591645/118813222-38671780-b8af-11eb-835b-f2865bab5c62.gif)
+![An animation of installing an extension directly in a RetroLab by running commands in a notebook cell.](https://user-images.githubusercontent.com/591645/118813222-38671780-b8af-11eb-835b-f2865bab5c62.gif)
 
 ### Switch between JupyterLab and RetroLab easily ↔️
 
-![jupyterlab-switch ...](https://user-images.githubusercontent.com/591645/118816963-05bf1e00-b8b3-11eb-92a2-899288471011.gif)
+![An animation of opening RetroLab in another tab from a button in the JupyterLab toolbar.](https://user-images.githubusercontent.com/591645/118816963-05bf1e00-b8b3-11eb-92a2-899288471011.gif)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Example with the [JupyterLab Miami Nights Theme](https://github.com/timkpaine/ju
 
 ### Zen Mode 😌
 
-![compact-zen-mode An animation of a user using the command palette to enable Zen Mode in JupyterLab](https://user-images.githubusercontent.com/591645/101923740-149cf880-3bd0-11eb-9617-e3349a76d034.gif)
+![An animation of a user using the command palette to enable Zen Mode in JupyterLab](https://user-images.githubusercontent.com/591645/101923740-149cf880-3bd0-11eb-9617-e3349a76d034.gif)
 
 ### Terminals 🖥️
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Example with the [JupyterLab Miami Nights Theme](https://github.com/timkpaine/ju
 
 ### Compact View on Mobile Devices 📱
 
-![mobile Animation of a user on a mobile phone-sized screen using a compact touch interface in JupyterLab](https://user-images.githubusercontent.com/591645/101995448-2793f380-3cca-11eb-8971-067dd068ccbe.gif)
+![Animation of a user on a mobile phone-sized screen using a compact touch interface in JupyterLab](https://user-images.githubusercontent.com/591645/101995448-2793f380-3cca-11eb-8971-067dd068ccbe.gif)
 
 ### Support for prebuilt extensions 🧩
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ jupyter retro --retro-logo
 
 Example with the [JupyterLab Miami Nights Theme](https://github.com/timkpaine/jupyterlab_miami_nights) installed as a prebuilt extension:
 
-![image The Jupyter interface using the Miami Nights theme](https://user-images.githubusercontent.com/591645/119634905-77e3b580-be13-11eb-9c4c-d187ebea9df8.png)
+![The Jupyter interface using the Miami Nights theme](https://user-images.githubusercontent.com/591645/119634905-77e3b580-be13-11eb-9c4c-d187ebea9df8.png)
 
 ### Zen Mode 😌
 

--- a/app/package.json
+++ b/app/package.json
@@ -135,7 +135,7 @@
     "glob": "~7.1.6",
     "mini-css-extract-plugin": "~0.9.0",
     "npm-run-all": "^4.1.5",
-    "playwright": "^1.12.3",
+    "playwright": "^1.17.1",
     "raw-loader": "~4.0.0",
     "rimraf": "~3.0.2",
     "style-loader": "~1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3298,7 +3298,7 @@
   integrity sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ==
 
 "@retrolab/application-extension@file:packages/application-extension":
-  version "0.3.12"
+  version "0.3.13"
   dependencies:
     "@jupyterlab/application" "^3.2.0"
     "@jupyterlab/apputils" "^3.2.0"
@@ -3315,11 +3315,11 @@
     "@lumino/coreutils" "^1.8.0"
     "@lumino/disposable" "^1.7.0"
     "@lumino/widgets" "^1.23.0"
-    "@retrolab/application" "^0.3.12"
-    "@retrolab/ui-components" "^0.3.12"
+    "@retrolab/application" "^0.3.13"
+    "@retrolab/ui-components" "^0.3.13"
 
 "@retrolab/application@file:packages/application":
-  version "0.3.12"
+  version "0.3.13"
   dependencies:
     "@jupyterlab/application" "^3.2.0"
     "@jupyterlab/coreutils" "^5.2.0"
@@ -3334,7 +3334,7 @@
     "@lumino/widgets" "^1.23.0"
 
 "@retrolab/console-extension@file:packages/console-extension":
-  version "0.3.12"
+  version "0.3.13"
   dependencies:
     "@jupyterlab/application" "^3.2.0"
     "@jupyterlab/console" "^3.2.0"
@@ -3342,7 +3342,7 @@
     "@lumino/algorithm" "^1.6.0"
 
 "@retrolab/docmanager-extension@file:packages/docmanager-extension":
-  version "0.3.12"
+  version "0.3.13"
   dependencies:
     "@jupyterlab/application" "^3.2.0"
     "@jupyterlab/coreutils" "^5.2.0"
@@ -3352,16 +3352,16 @@
     "@lumino/algorithm" "^1.6.0"
 
 "@retrolab/help-extension@file:packages/help-extension":
-  version "0.3.12"
+  version "0.3.13"
   dependencies:
     "@jupyterlab/application" "^3.2.0"
     "@jupyterlab/apputils" "^3.2.0"
     "@jupyterlab/mainmenu" "^3.2.0"
     "@jupyterlab/translation" "^3.2.0"
-    "@retrolab/ui-components" "^0.3.12"
+    "@retrolab/ui-components" "^0.3.13"
 
 "@retrolab/lab-extension@file:packages/lab-extension":
-  version "0.3.12"
+  version "0.3.13"
   dependencies:
     "@jupyterlab/application" "^3.2.0"
     "@jupyterlab/apputils" "^3.2.0"
@@ -3373,11 +3373,11 @@
     "@jupyterlab/ui-components" "^3.2.0"
     "@lumino/commands" "^1.15.0"
     "@lumino/disposable" "^1.7.0"
-    "@retrolab/application" "^0.3.12"
-    "@retrolab/ui-components" "^0.3.12"
+    "@retrolab/application" "^0.3.13"
+    "@retrolab/ui-components" "^0.3.13"
 
 "@retrolab/notebook-extension@file:packages/notebook-extension":
-  version "0.3.12"
+  version "0.3.13"
   dependencies:
     "@jupyterlab/application" "^3.2.0"
     "@jupyterlab/apputils" "^3.2.0"
@@ -3386,10 +3386,10 @@
     "@jupyterlab/translation" "^3.2.0"
     "@lumino/polling" "^1.6.0"
     "@lumino/widgets" "^1.23.0"
-    "@retrolab/application" "^0.3.12"
+    "@retrolab/application" "^0.3.13"
 
 "@retrolab/terminal-extension@file:packages/terminal-extension":
-  version "0.3.12"
+  version "0.3.13"
   dependencies:
     "@jupyterlab/application" "^3.2.0"
     "@jupyterlab/coreutils" "^5.2.0"
@@ -3397,7 +3397,7 @@
     "@lumino/algorithm" "^1.6.0"
 
 "@retrolab/tree-extension@file:packages/tree-extension":
-  version "0.3.12"
+  version "0.3.13"
   dependencies:
     "@jupyterlab/application" "^3.2.0"
     "@jupyterlab/apputils" "^3.2.0"
@@ -3413,10 +3413,10 @@
     "@lumino/algorithm" "^1.6.0"
     "@lumino/commands" "^1.15.0"
     "@lumino/widgets" "^1.23.0"
-    "@retrolab/application" "^0.3.12"
+    "@retrolab/application" "^0.3.13"
 
 "@retrolab/ui-components@file:packages/ui-components":
-  version "0.3.12"
+  version "0.3.13"
   dependencies:
     "@jupyterlab/ui-components" "^3.2.0"
     react "^17.0.1"
@@ -4200,7 +4200,7 @@ agent-base@4, agent-base@^4.3.0:
   dependencies:
     es6-promisify "^5.0.0"
 
-agent-base@6:
+agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
@@ -5282,7 +5282,7 @@ commander@2.17.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@^6.1.0, commander@^6.2.0:
+commander@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
@@ -5291,6 +5291,11 @@ commander@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+commander@^8.2.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 commander@~2.19.0:
   version "2.19.0"
@@ -8009,7 +8014,7 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
-ip@1.1.5:
+ip@1.1.5, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
@@ -10984,12 +10989,12 @@ pkginfo@0.4.1:
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
   integrity sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=
 
-playwright@^1.12.3:
-  version "1.12.3"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.12.3.tgz#113afa2cba10fb56e9a5b307377343e32a155a99"
-  integrity sha512-eyhHvZV7dMAUltqjQsgJ9CjZM8dznzN1+rcfCI6W6lfQ7IlPvTFGLuKOCcI4ETbjfbxqaS5FKIkb1WDDzq2Nww==
+playwright-core@=1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.17.1.tgz#a16e0f89284a0ed8ae6d77e1c905c84b8a2ba022"
+  integrity sha512-C3c8RpPiC3qr15fRDN6dx6WnUkPLFmST37gms2aoHPDRvp7EaGDPMMZPpqIm/QWB5J40xDrQCD4YYHz2nBTojQ==
   dependencies:
-    commander "^6.1.0"
+    commander "^8.2.0"
     debug "^4.1.1"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.0"
@@ -11000,9 +11005,18 @@ playwright@^1.12.3:
     proper-lockfile "^4.1.1"
     proxy-from-env "^1.1.0"
     rimraf "^3.0.2"
+    socks-proxy-agent "^6.1.0"
     stack-utils "^2.0.3"
     ws "^7.4.6"
+    yauzl "^2.10.0"
     yazl "^2.5.1"
+
+playwright@^1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.17.1.tgz#a6d63302ee40f41283c4bf869de261c4743a787c"
+  integrity sha512-DisCkW9MblDJNS3rG61p8LiLA2WA7IY/4A4W7DX4BphWe/HuWjKmGQptuk4NVIh5UuSwXpW/jaH2+ZgjHs3GMA==
+  dependencies:
+    playwright-core "=1.17.1"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -12359,6 +12373,23 @@ socks-proxy-agent@^4.0.0:
   dependencies:
     agent-base "~4.2.1"
     socks "~2.3.2"
+
+socks-proxy-agent@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz#e664e8f1aaf4e1fb3df945f09e3d94f911137f87"
+  integrity sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==
+  dependencies:
+    agent-base "^6.0.2"
+    debug "^4.3.1"
+    socks "^2.6.1"
+
+socks@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
+  integrity sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.1.0"
 
 socks@~2.3.2:
   version "2.3.3"


### PR DESCRIPTION
I was too slow making edits on this and the last working PR got merged before I finished. Sorry about that! This follow-up PR
- Makes style edits for consistency (particularly punctuation pages)
- Combines suggested alt text for images that had multiple suggestions

Ideally will make changes [to this RetroLab alt text PR](https://github.com/jupyterlab/retrolab/pull/306)

--- 

I tried to rebase multiple times and failed, so please let me know if there's something I can do to help make these changes easier to adopt. Thanks.